### PR TITLE
Fix/lapi empty response

### DIFF
--- a/config/crowdsec-apache2-bouncer.conf
+++ b/config/crowdsec-apache2-bouncer.conf
@@ -1,5 +1,9 @@
 ## Basic configuration
-CrowdsecURL http://127.0.0.1:8080 # Make sure there is no trailing forward slash
+
+# Must be of the form http://<authority>
+# Anything after the authority (path, query, or fragment) in URL will be
+# ignored and a warning will be printed to logs
+CrowdsecURL http://127.0.0.1:8080
 CrowdsecAPIKey $API_KEY
 
 # Behavior if we can't reach (or timeout) LAPI

--- a/config/crowdsec-apache2-bouncer.conf
+++ b/config/crowdsec-apache2-bouncer.conf
@@ -1,5 +1,5 @@
 ## Basic configuration
-CrowdsecURL http://127.0.0.1:8080/
+CrowdsecURL http://127.0.0.1:8080 # Make sure there is no trailing forward slash
 CrowdsecAPIKey $API_KEY
 
 # Behavior if we can't reach (or timeout) LAPI

--- a/mod_crowdsec.c
+++ b/mod_crowdsec.c
@@ -427,7 +427,8 @@ static int crowdsec_proxy(request_rec * r, const char **response)
                   "'%d') from url: %s",
                   status, rr->status, rr->filename);
 
-    if (HTTP_NOT_FOUND == status || (!status && HTTP_NOT_FOUND == rr->status)) {
+    if (HTTP_NOT_FOUND == status ||
+        (status == OK && HTTP_NOT_FOUND == rr->status)) {
         ap_log_rerror(APLOG_MARK, APLOG_ERR, APR_SUCCESS, r,
                       "crowdsec: we received a 404 Not Found when speaking "
                       "to the crowdsec service '%s', you might be pointing at "
@@ -437,7 +438,7 @@ static int crowdsec_proxy(request_rec * r, const char **response)
         return HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    else if ((status)) {
+    else if (status != OK) {
 
         crowdsec_config_rec *conf = (crowdsec_config_rec *)
             ap_get_module_config(r->per_dir_config,

--- a/mod_crowdsec.c
+++ b/mod_crowdsec.c
@@ -422,7 +422,12 @@ static int crowdsec_proxy(request_rec * r, const char **response)
 
     status = ap_run_sub_req(rr);
 
-    if (HTTP_NOT_FOUND == status) {
+    ap_log_rerror(APLOG_MARK, APLOG_DEBUG, APR_SUCCESS, r,
+                  "crowdsec: function call status is '%d' (response status is "
+                  "'%d') from url: %s",
+                  status, rr->status, rr->filename);
+
+    if (HTTP_NOT_FOUND == status || (!status && HTTP_NOT_FOUND == rr->status)) {
         ap_log_rerror(APLOG_MARK, APLOG_ERR, APR_SUCCESS, r,
                       "crowdsec: we received a 404 Not Found when speaking "
                       "to the crowdsec service '%s', you might be pointing at "


### PR DESCRIPTION
- Fixes the default config to work with the default LAPI config.
- Adds extra error handling to properly distinguish when the LAPI request 404s due to double backslashes (e.g. `http://localhost:8080//v1/decisions?ip=`). Before this patch, `crowdsec_proxy()` would return `OK` with the response being the empty string.