### PR TITLE
Fixes service reload errors from installation scripts when apache is not running

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -20,5 +20,5 @@ a2enmod  mod_crowdsec
 if [ "$START" -eq 0 ]; then
     echo "no api key was generated, you can generate one on your LAPI server by running 'cscli bouncers add <bouncer_name>' and add it to '$CONFIG'" >&2
 else
-    systemctl reload apache2
+    systemctl try-reload-or-restart apache2
 fi

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 a2dismod  mod_crowdsec
-systemctl reload apache2
+systemctl try-reload-or-restart apache2
 


### PR DESCRIPTION
Prior to this patch, if the apache service was not running when mod_crowdsec was installed, the `prerm` and `postinst` scripts would both fail when trying to reload apache.

This changes `systemctl reload apache2` to instead `systemctl try-reload-or-restart apache2` inside `prerm` and `postinst` scripts which will only reload or restart if apache is running. Otherwise, the command will be idempotent and do nothing.