### PR TITLE
get rid of debhelper version dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: crowdsec-apache2-bouncer
 Section: httpd
 Priority: optional
 Maintainer: Crowdsec Team <support@crowdsec.net>
-Build-Depends: debhelper (>> 13), apache2-dev, pkg-config
+Build-Depends: debhelper, apache2-dev, pkg-config
 Depends: apache2
 Standards-Version: 1.0.0
 Homepage: https://github.com/buixor/mod_crowdsec


### PR DESCRIPTION
get rid of debhelper version dependency